### PR TITLE
Fix: small icon viewmode text width

### DIFF
--- a/arm9/source/mainlist.cpp
+++ b/arm9/source/mainlist.cpp
@@ -445,7 +445,7 @@ void cMainList::setViewMode(VIEW_MODE mode) {
             break;
         case VM_LIST_ICON:
             _columns[ICON_COLUMN].width = 18;
-            _columns[SHOWNAME_COLUMN].width = 250;
+            _columns[SHOWNAME_COLUMN].width = 232;
             _columns[INTERNALNAME_COLUMN].width = 0;
             arangeColumnsSize();
             setRowHeight(15);


### PR DESCRIPTION
## What was fixed
Fixed text spacing issue in the small icon viewmode that was causing long text to appear on the other side of the screen.

## Changes made
- Adjusted _SHOWNAME_COLUMN_ width for the _VM_LIST_ in **mainlist.cpp** (line 448) to include the _ICON_COLUMN_ width for the for total width of 250 as in the other viewmodes.
