### PR TITLE
Fix autorunWithLastRom support

### DIFF
--- a/arm9/source/romlauncher.cpp
+++ b/arm9/source/romlauncher.cpp
@@ -280,5 +280,5 @@ TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool 
 void autoLaunchRom(const std::string& aFullPath) {
     DSRomInfo rominfo;
     rominfo.MayBeDSRom(aFullPath);
-    if (rominfo.isDSRom()) launchRom(aFullPath, rominfo, false, NULL);
+    if (rominfo.isDSRom()) launchRom(aFullPath, rominfo, false, "");
 }


### PR DESCRIPTION
Enabling autorunWithLastRom will lead to AKMenu freezing upon boot. This small patch seems to fix it, allowing the rom to autoboot correctly