### PR TITLE
mainwnd: improve settings menu internationalisation

### DIFF
--- a/arm9/source/mainwnd.cpp
+++ b/arm9/source/mainwnd.cpp
@@ -547,19 +547,19 @@ void cMainWnd::setParam(void) {
     _values.push_back(".sav");
     settingWnd.addSettingItem(LANG("file settings", "save extension"), _values, gs().saveExt);
     _values.clear();
-    _values.push_back("no");
-    _values.push_back("yes");
+    _values.push_back(LANG("message box", "no"));
+    _values.push_back(LANG("message box", "yes"));
     settingWnd.addSettingItem(LANG("file settings", "use saves folder"), _values, gs().saveDir);
 
     // page 4: ndsbs
     settingWnd.addSettingTab(LANG("setting window", "patches"));
     _values.clear();
-    _values.push_back("disable");
-    _values.push_back("enable");
+    _values.push_back(LANG("switches", "Disable"));
+    _values.push_back(LANG("switches", "Enable"));
     settingWnd.addSettingItem(LANG("nds bootstrap", "dsmode"), _values, gs().dsOnly);
     _values.clear();
-    _values.push_back("release");
-    _values.push_back("nightly");
+    _values.push_back(LANG("nds bootstrap", "release"));
+    _values.push_back(LANG("nds bootstrap", "nightly"));
     settingWnd.addSettingItem(LANG("nds bootstrap", "text"), _values, gs().nightly);
 
     _values.clear();
@@ -576,8 +576,8 @@ void cMainWnd::setParam(void) {
 
 #ifdef __DSIMODE__
     _values.clear();
-    _values.push_back("disable");
-    _values.push_back("enable");
+    _values.push_back(LANG("switches", "Disable"));
+    _values.push_back(LANG("switches", "Enable"));
     settingWnd.addSettingItem(LANG("nds bootstrap", "phatCol"), _values, gs().phatCol);
 #else
     _values.clear();

--- a/language/Deutsch/language.txt
+++ b/language/Deutsch/language.txt
@@ -324,8 +324,8 @@ load text = Bitte warten…
 
 [nds bootstrap]
 text = nds-bootstrap version
-item0 = release
-item1 = nightly
+release = release
+nightly = nightly
 firsttimetitle = NDS-Bootstrap wird initialisiert
 firsttime = Drücken Sie OK, um die Ersteinrichtung von NDS-Bootstrap zu starten. Dies kann eine Minute dauern und ist ein einmaliger Vorgang.
 dsmode = DS-Only Mode

--- a/language/English/language.txt
+++ b/language/English/language.txt
@@ -150,8 +150,8 @@ item2 = ALL
 
 [nds bootstrap]
 text = nds-bootstrap version
-item0 = release
-item1 = nightly
+release = release
+nightly = nightly
 firsttimetitle = Initializing nds-bootstrap
 firsttime = Press OK to start first-time setup of nds-bootstrap. This may take a minute and is a one-time process.
 dsmode = DS-Only Mode

--- a/language/Español/language.txt
+++ b/language/Español/language.txt
@@ -329,8 +329,8 @@ load text = Espere por favor…
 
 [nds bootstrap]
 text = nds-bootstrap version
-item0 = release
-item1 = nightly
+release = release
+nightly = nightly
 firsttimetitle = Inicializando nds-bootstrap
 firsttime = Pulsa "Aceptar" para iniciar la configuración inicial de nds-bootstrap. Este proceso puede tardar un minuto y se realiza una sola vez.
 dsmode = DS-Only Mode

--- a/language/Français/language.txt
+++ b/language/Français/language.txt
@@ -150,8 +150,8 @@ item2 = TOUS
 
 [nds bootstrap]
 text = Version d'NDS-Bootstrap
-item0 = Stable
-item1 = Bêta
+release = Stable
+nightly = Bêta
 firsttimetitle = Initialisation d'NDS-Bootstrap
 firsttime = Appuyez sur OK pour lancer la première configuration d'NDS-Bootstrap. Cette opération peut prendre une minute et est unique.
 dsmode = Mode DS seulement

--- a/language/Italiano/language.txt
+++ b/language/Italiano/language.txt
@@ -322,8 +322,8 @@ load text = Attendere prego…
 
 [nds bootstrap]
 text = nds-bootstrap version
-item0 = release
-item1 = nightly
+release = release
+nightly = nightly
 firsttimetitle = Inizializzazione di nds-bootstrap
 firsttime = Premere OK per avviare la configurazione iniziale di nds-bootstrap. Questa operazione potrebbe richiedere un minuto ed è un'operazione da eseguire una sola volta.
 dsmode = DS-Only Mode

--- a/language/日本語 (JP)/language.txt
+++ b/language/日本語 (JP)/language.txt
@@ -322,8 +322,8 @@ load text = お待ちください...
 
 [nds bootstrap]
 text = nds-bootstrapバージョン
-item0 = release
-item1 = nightly
+release = release
+nightly = nightly
 firsttimetitle = nds-bootstrapの初期化
 firsttime = 「OK」を押すと、nds-bootstrapの初回セットアップが開始されます。このプロセスは1分ほどかかる場合があり、一度だけ実行されます。
 dsmode = DS専用モード

--- a/language/简体中文 (CN)/language.txt
+++ b/language/简体中文 (CN)/language.txt
@@ -159,8 +159,8 @@ item1 = 禁用
 
 [nds bootstrap]
 text = nds-bootstrap版本
-item0 = 正式版
-item1 = 每夜版
+release = 正式版
+nightly = 每夜版
 firsttimetitle = 初始化 nds-bootstrap
 firsttime = 按“确定”开始 nds-bootstrap 的首次设置。此过程可能需要一分钟，并且是一次性过程。
 dsmode = DS-Only 模式

--- a/language/繁體中文 (ZH)/language.txt
+++ b/language/繁體中文 (ZH)/language.txt
@@ -159,8 +159,8 @@ item1 = 是
 
 [nds bootstrap]
 text = nds-bootstrap版本
-item0 = release版
-item1 = nightly版
+release = release版
+nightly = nightly版
 firsttimetitle = 初始化 nds-bootstrap
 firsttime = 按“OK”開始 nds-bootstrap 的首次設定。這可能需要一分鐘，並且是一次性過程。
 dsmode = DS-Only 模式


### PR DESCRIPTION
There are several hard-coded English strings in the settings menu. Many of these strings already have a translated counterpart within the language files. This commit improves upon the translations in the settings menu by swapping the hard-coded strings with those from the language file loaded.