### PR TITLE
Add DSpico DSi mode support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ checkarm9_dsi: nds-bootloader
 	$(MAKE) -C arm9_dsi
 
 #---------------------------------------------------------------------------------
+checkarm9_pico: nds-bootloader
+	$(MAKE) -C arm9_dsi_pico
+
+#---------------------------------------------------------------------------------
 $(TARGET).nds : $(NITRO_FILES) checkarm7 checkarm9
 	ndstool	-c $(TARGET).nds -7 arm7/$(TARGET).elf -9 arm9/$(TARGET).elf \
 	-h 0x200 -t banner.bin \
@@ -69,11 +73,12 @@ $(TARGET).dsi : $(NITRO_FILES) checkarm7 checkarm9_dsi
 	-g NEXT 01 "AKMENU" -z 80040407 -u 00030004 -a 00000138 -p 0001 \
 	$(_ADDFILES)
 
-boot_pico.nds : $(NITRO_FILES) checkarm7 checkarm9
+boot_pico.nds : $(NITRO_FILES) checkarm7 checkarm9_pico
 	ndstool -c boot_pico.nds \
 		-7 arm7/$(TARGET).elf \
-		-9 arm9/$(TARGET).elf \
-		-h 0x200 -t banner.bin \
+		-9 arm9_dsi_pico/$(TARGET).elf \
+		-t banner.bin \
+		-g NEXT 01 "AKMENU" -z 80040407 -u 00030004 -a 00000138 -p 0001 \
 		$(_ADDFILES)
 
 #---------------------------------------------------------------------------------

--- a/arm9/source/helpwnd.cpp
+++ b/arm9/source/helpwnd.cpp
@@ -45,7 +45,7 @@ cHelpWnd::cHelpWnd(s32 x, s32 y, u32 w, u32 h, cWindow* parent, const std::strin
     }
     _helpText = formatString(_helpText.c_str(), 7, 1, 2, 4, 3, 5, 6, "START", "SELECT");
 
-    #ifdef __DSIMODE__
+    #if defined(__DSIMODE__) && !defined(__DSPICO__)
         const char* ndsbsVer = "sd:/_nds/release-bootstrap.ver";
     #else
         const char* ndsbsVer = "fat:/_nds/release-bootstrap.ver";

--- a/arm9/source/launcher/NdsBootstrapLauncher.cpp
+++ b/arm9/source/launcher/NdsBootstrapLauncher.cpp
@@ -90,13 +90,13 @@ bool NdsBootstrapLauncher::prepareIni(bool hb) {
 
     ini.SetString("NDS-BOOTSTRAP", "SAV_PATH", mSavePath);
 
-    #ifdef __DSIMODE__
+    #if defined(__DSIMODE__) && !defined(__DSPICO__)
         ini.SetString("NDS-BOOTSTRAP", "QUIT_PATH", "sd:/_nds/akmenunext/launcher.nds");
     #else
         ini.SetString("NDS-BOOTSTRAP", "QUIT_PATH", "fat:/_nds/akmenunext/launcher.nds");
     #endif
 
-    #ifdef __DSIMODE__
+    #if defined(__DSIMODE__) && !defined(__DSPICO__)
         const char* custIniPath = "sd:/_nds/akmenunext/ndsbs.ini";
     #else
         const char* custIniPath = "fat:/_nds/akmenunext/ndsbs.ini";

--- a/arm9/source/launcher/Slot1Launcher.cpp
+++ b/arm9/source/launcher/Slot1Launcher.cpp
@@ -14,7 +14,7 @@
 
 bool Slot1Launcher::launchRom(std::string romPath, std::string savePath, u32 flags,
                                u32 cheatOffset, u32 cheatSize, bool hb) {
-    #ifdef __DSIMODE__
+    #if defined(__DSIMODE__) && !defined(__DSPICO__)
         const char slot1LoaderPath[] = "sd:/_nds/akmenunext/slot1launch.nds";
     #else
         const char slot1LoaderPath[] = "fat:/_nds/akmenunext/slot1launch.nds";

--- a/arm9/source/mainlist.cpp
+++ b/arm9/source/mainlist.cpp
@@ -110,7 +110,7 @@ static bool extnameFilter(const std::vector<std::string>& extNames, std::string 
 
 bool cMainList::enterDir(const std::string& dirName) {
 
-#ifdef __DSIMODE__
+#if defined(__DSIMODE__) && !defined(__DSPICO__)
     const char* base = "sd:/_nds/akmenunext/icons/";
 #else
     const char* base = "fat:/_nds/akmenunext/icons/";

--- a/arm9/source/mainlist.h
+++ b/arm9/source/mainlist.h
@@ -17,10 +17,10 @@
 #include "touchmessage.h"
 #include "zoomingicon.h"
 
-#ifndef __DSIMODE__
-#define SD_ROOT_0 "fat:"
-#else
+#if defined(__DSIMODE__)  && !defined(__DSPICO__)
 #define SD_ROOT_0 "sd:"
+#else
+#define SD_ROOT_0 "fat:"
 #endif
 #define SD_ROOT SD_ROOT_0 "/"
 

--- a/arm9/source/mainwnd.cpp
+++ b/arm9/source/mainwnd.cpp
@@ -574,12 +574,14 @@ void cMainWnd::setParam(void) {
     _values.push_back(LANG("override", "8"));
     settingWnd.addSettingItem(LANG("override", "text"), _values, gs().languageOverride);
 
+
 #ifdef __DSIMODE__
     _values.clear();
     _values.push_back(LANG("switches", "Disable"));
     _values.push_back(LANG("switches", "Enable"));
     settingWnd.addSettingItem(LANG("nds bootstrap", "phatCol"), _values, gs().phatCol);
-#else
+#endif
+#if !defined(__DSIMODE__) || defined(__DSPICO__)
     _values.clear();
     _values.push_back("nds-bootstrap");
     _values.push_back("Pico-Loader");
@@ -651,6 +653,10 @@ void cMainWnd::setParam(void) {
     gs().pico = settingWnd.getItemSelection(3, 3);
 #endif
 
+#ifdef __DSPICO__
+    gs().pico = settingWnd.getItemSelection(3, 4);
+#endif
+
     // page 5: other
     gs().cheats = settingWnd.getItemSelection(4, 0);
     gs().slot2mode = settingWnd.getItemSelection(4, 1);
@@ -665,7 +671,7 @@ void cMainWnd::setParam(void) {
             gs().uiName = uiNames[uiIndexAfter];
             gs().langDirectory = langNames[langIndexAfter];
             gs().saveSettings();
-            #ifdef __DSIMODE__ 
+            #if defined(__DSIMODE__)  && !defined(__DSPICO__)
             HomebrewLauncher().launchRom("sd:/_nds/akmenunext/launcher.nds", "", 0, 0, 0, 0);
             #else
             HomebrewLauncher().launchRom("fat:/_nds/akmenunext/launcher.nds", "", 0, 0, 0, 0);
@@ -679,7 +685,7 @@ void cMainWnd::setParam(void) {
         if (ID_YES == ret) {
             gs().langDirectory = langNames[langIndexAfter];
             gs().saveSettings();
-            #ifdef __DSIMODE__ 
+            #if defined(__DSIMODE__)  && !defined(__DSPICO__)
             HomebrewLauncher().launchRom("sd:/_nds/akmenunext/launcher.nds", "", 0, 0, 0, 0);
             #else
             HomebrewLauncher().launchRom("fat:/_nds/akmenunext/launcher.nds", "", 0, 0, 0, 0);

--- a/arm9/source/systemfilenames.h
+++ b/arm9/source/systemfilenames.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#ifndef __DSIMODE__
-#define SFN_SYSTEM_DIR "fat:/_nds/akmenunext/"
-#else
+#if defined(__DSIMODE__) && !defined(__DSPICO__)
 #define SFN_SYSTEM_DIR "sd:/_nds/akmenunext/"
+#else
+#define SFN_SYSTEM_DIR "fat:/_nds/akmenunext/"
 #endif
 #define SFN_OFFICIAL_SAVELIST SFN_SYSTEM_DIR "savelist.bin"
 #define SFN_CUSTOM_SAVELIST SFN_SYSTEM_DIR "gamedata.bin"

--- a/arm9_dsi_pico/Makefile
+++ b/arm9_dsi_pico/Makefile
@@ -1,0 +1,142 @@
+#---------------------------------------------------------------------------------
+.SUFFIXES:
+#---------------------------------------------------------------------------------
+ifeq ($(strip $(DEVKITARM)),)
+$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
+endif
+
+include $(DEVKITARM)/ds_rules
+
+SOURCE_PATH := ../arm9
+#---------------------------------------------------------------------------------
+# BUILD is the directory where object files & intermediate files will be placed
+# SOURCES is a list of directories containing source code
+# INCLUDES is a list of directories containing extra header files
+# DATA is a list of directories containing binary files embedded using bin2o
+# GRAPHICS is a list of directories containing image files to be converted with grit
+# all directories are relative to this makefile
+#---------------------------------------------------------------------------------
+BUILD    := build
+SOURCES  := $(SOURCE_PATH)/source $(SOURCE_PATH)/source/ui $(SOURCE_PATH)/source/font $(SOURCE_PATH)/source/launcher $(SOURCE_PATH)/source/saves
+INCLUDES := $(SOURCE_PATH)/include ../share $(SOURCES)
+DATA     := $(SOURCE_PATH)/data ../data
+GRAPHICS :=
+
+#---------------------------------------------------------------------------------
+# options for code generation
+#---------------------------------------------------------------------------------
+ARCH := -marm -mthumb-interwork -march=armv5te -mtune=arm946e-s
+
+CFLAGS   := -g -Wall -O3\
+			-Wno-address-of-packed-member \
+            $(ARCH) $(INCLUDE) -DARM9
+
+CFLAGS   += -D_NO_BOOTSTUB_ -D__DSIMODE__ -D__DSPICO__
+
+CXXFLAGS := $(CFLAGS) -fno-rtti -fno-exceptions
+ASFLAGS  := -g $(ARCH) $(INCLUDE)
+LDFLAGS   = -specs=ds_arm9.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
+
+#---------------------------------------------------------------------------------
+# any extra libraries we wish to link with the project
+#---------------------------------------------------------------------------------
+LIBS := -lfat -lnds9
+
+#---------------------------------------------------------------------------------
+# list of directories containing libraries, this must be the top level containing
+# include and lib
+#---------------------------------------------------------------------------------
+LIBDIRS := $(LIBNDS) $(PORTLIBS)
+
+#---------------------------------------------------------------------------------
+# no real need to edit anything past this point unless you need to add additional
+# rules for different file extensions
+#---------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#---------------------------------------------------------------------------------
+
+export ARM9ELF := $(CURDIR)/$(TARGET).elf
+
+export VPATH := $(foreach dir,$(SOURCES),$(CURDIR)/$(dir))\
+                $(foreach dir,$(DATA),$(CURDIR)/$(dir))\
+                $(foreach dir,$(GRAPHICS),$(CURDIR)/$(dir))
+
+export DEPSDIR := $(CURDIR)/$(BUILD)
+
+CFILES   := $(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+CPPFILES := $(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
+SFILES   := $(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+PNGFILES := $(foreach dir,$(GRAPHICS),$(notdir $(wildcard $(dir)/*.png)))
+BINFILES := $(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+
+#---------------------------------------------------------------------------------
+# use CXX for linking C++ projects, CC for standard C
+#---------------------------------------------------------------------------------
+ifeq ($(strip $(CPPFILES)),)
+#---------------------------------------------------------------------------------
+  export LD := $(CC)
+#---------------------------------------------------------------------------------
+else
+#---------------------------------------------------------------------------------
+  export LD := $(CXX)
+#---------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------
+
+export OFILES_BIN   :=	$(addsuffix .o,$(BINFILES))
+
+export OFILES_SOURCES := $(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+
+export OFILES := $(PNGFILES:.png=.o) $(OFILES_BIN) $(OFILES_SOURCES)
+
+export HFILES := $(PNGFILES:.png=.h) $(addsuffix .h,$(subst .,_,$(BINFILES)))
+
+export INCLUDE  := $(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir))\
+                   $(foreach dir,$(LIBDIRS),-I$(dir)/include)\
+                   -I$(CURDIR)/$(BUILD)
+export LIBPATHS := $(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
+.PHONY: $(BUILD) clean
+
+#---------------------------------------------------------------------------------
+$(BUILD):
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+
+#---------------------------------------------------------------------------------
+clean:
+	@echo clean ...
+	@rm -fr $(BUILD) $(TARGET).elf
+
+
+#---------------------------------------------------------------------------------
+else
+
+#---------------------------------------------------------------------------------
+# main targets
+#---------------------------------------------------------------------------------
+$(ARM9ELF) : $(OFILES)
+	@echo linking $(notdir $@)
+	@$(LD)  $(LDFLAGS) $(OFILES) $(LIBPATHS) $(LIBS) -o $@
+
+#---------------------------------------------------------------------------------
+%.bin.o %_bin.h : %.bin
+#---------------------------------------------------------------------------------
+	@echo $(notdir $<)
+	@$(bin2o)
+
+#---------------------------------------------------------------------------------
+# This rule creates assembly source files using grit
+# grit takes an image file and a .grit describing how the file is to be processed
+# add additional rules like this for each image extension
+# you use in the graphics folders
+#---------------------------------------------------------------------------------
+%.s %.h: %.png %.grit
+#---------------------------------------------------------------------------------
+	grit $< -fts -o$*
+
+-include $(DEPSDIR)/*.d
+
+#---------------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------------


### PR DESCRIPTION
It's possible to not create a new Makefile and modify arm9_dsi instead, but it's going to make it even more difficult to maintain. A makefile per .elf is prefered imo.

This has been tested on DSi and DS Lite, works as expected.