### PR TITLE
dsrom: fix Battle of Giants Mutant Insects

### DIFF
--- a/arm9/source/dsrom.cpp
+++ b/arm9/source/dsrom.cpp
@@ -71,7 +71,8 @@ bool DSRomInfo::loadDSRomInfo(const std::string& filename, bool loadBanner) {
         _isModernHomebrew = ETrue;
         u32 arm9StartSig[4] = {0};
         //Seek to ARM9 entry point and read first 4 instructions
-        fseek(f, (u32)header.arm9romOffset + (u32)header.arm9executeAddress - (u32)header.arm9destination, SEEK_SET);
+        // "Battle/Combat of Giants: Mutant Insects" (TID: BIG) has code that is run before the actual SDK boot code
+        fseek(f, (u32)header.arm9romOffset + ((strncmp(header.gameCode, "BIG", 3) == 0) ? 0x02000800 : (u32)header.arm9executeAddress) - (u32)header.arm9destination, SEEK_SET);
         fread(arm9StartSig, sizeof(u32), 4, f);
 
          //Check for Nintendo SDK style retail builds


### PR DESCRIPTION
This game gets detected as homebrew since it has code that is run before the actual SDK boot code. This patch ports over the fix from TWiLight Menu++ commit [75d5c3cf18fb0fa025ed4c5fd1556684d87be61b](https://github.com/DS-Homebrew/TWiLightMenu/commit/75d5c3cf18fb0fa025ed4c5fd1556684d87be61b).

I have added RocketRobz as a co-author since he wrote the original patch this was based on.