### PR TITLE
Reduce duplicated code

### DIFF
--- a/arm9/source/dsrom.cpp
+++ b/arm9/source/dsrom.cpp
@@ -186,54 +186,30 @@ void DSRomInfo::drawDSRomIcon(u8 x, u8 y, GRAPHICS_ENGINE engine, bool small) {
             gdi().maskBlt(icon_bg_bin, x, y, 32, 32, engine);
             break;
     }
-    
-    if (small) {
-        // Draw 16x16px
-        for (int tile = 0; tile < 16; ++tile) {
-            for (int pixel = 0; pixel < 32; ++pixel) {
-                u8 a_byte = _banner.icon[(tile << 5) + pixel];
 
-                int px = ((tile & 3) << 3) + ((pixel << 1) & 7);
-                int py = ((tile >> 2) << 3) + (pixel >> 2);
+    for (int tile = 0; tile < 16; ++tile) {
+        for (int pixel = 0; pixel < 32; ++pixel) {
+            u8 a_byte = _banner.icon[(tile << 5) + pixel];
 
-                u8 idx1 = (a_byte & 0xf0) >> 4;
-                u8 idx2 = (a_byte & 0x0f);
+            int px = ((tile & 3) << 3) + ((pixel << 1) & 7);
+            int py = ((tile >> 2) << 3) + (pixel >> 2);
 
-                int small_px = px / 2;
-                int small_py = py / 2;
-
-                if (skiptransparent || 0 != idx1) {
-                    gdi().setPenColor(_banner.palette[idx1], engine);
-                    gdi().drawPixel(small_px + 1 + x, small_py + y, engine);
-                }
-
-                if (skiptransparent || 0 != idx2) {
-                    gdi().setPenColor(_banner.palette[idx2], engine);
-                    gdi().drawPixel(small_px + x, small_py + y, engine);
-                }
+            if(small){
+                px /= 2;
+                py /= 2;
             }
-        }
-    } else {
-        // Draw 32x32px
-        for (int tile = 0; tile < 16; ++tile) {
-            for (int pixel = 0; pixel < 32; ++pixel) {
-                u8 a_byte = _banner.icon[(tile << 5) + pixel];
 
-                int px = ((tile & 3) << 3) + ((pixel << 1) & 7);
-                int py = ((tile >> 2) << 3) + (pixel >> 2);
+            u8 idx1 = (a_byte & 0xf0) >> 4;
+            u8 idx2 = (a_byte & 0x0f);
 
-                u8 idx1 = (a_byte & 0xf0) >> 4;
-                u8 idx2 = (a_byte & 0x0f);
+            if (skiptransparent || 0 != idx1) {
+                gdi().setPenColor(_banner.palette[idx1], engine);
+                gdi().drawPixel(px + 1 + x, py + y, engine);
+            }
 
-                if (skiptransparent || 0 != idx1) {
-                    gdi().setPenColor(_banner.palette[idx1], engine);
-                    gdi().drawPixel(px + 1 + x, py + y, engine);
-                }
-
-                if (skiptransparent || 0 != idx2) {
-                    gdi().setPenColor(_banner.palette[idx2], engine);
-                    gdi().drawPixel(px + x, py + y, engine);
-                }
+            if (skiptransparent || 0 != idx2) {
+                gdi().setPenColor(_banner.palette[idx2], engine);
+                gdi().drawPixel(px + x, py + y, engine);
             }
         }
     }

--- a/arm9/source/mainlist.cpp
+++ b/arm9/source/mainlist.cpp
@@ -453,9 +453,12 @@ void cMainList::draw() {
 
 void cMainList::drawIcons()  // 直接画家算法画 icons
 {
-    if (VM_LIST_ICON == _viewMode){
+    if (VM_LIST != _viewMode){
         size_t total = _visibleRowCount;
         if (total > _rows.size() - _firstVisibleRowId) total = _rows.size() - _firstVisibleRowId;
+
+        int icon_height = (VM_LIST_ICON == _viewMode) ? 16 : 32;
+        bool small = (VM_LIST_ICON == _viewMode) ? true : false;
 
         for (size_t i = 0; i < total; ++i) {
             // 这里图像呈现比真正的 MAIN buffer 翻转要早，所以会闪一下
@@ -466,25 +469,8 @@ void cMainList::drawIcons()  // 直接画家算法画 icons
                 }
             }
             s32 itemX = _position.x + 1;
-            s32 itemY = _position.y + i * _rowHeight + ((_rowHeight - 16) >> 1) - 1;
-            _romInfoList[_firstVisibleRowId + i].drawDSRomIcon(itemX, itemY, _engine, true);
-        }
-    }
-    else if (VM_LIST != _viewMode) {
-        size_t total = _visibleRowCount;
-        if (total > _rows.size() - _firstVisibleRowId) total = _rows.size() - _firstVisibleRowId;
-
-        for (size_t i = 0; i < total; ++i) {
-            // 这里图像呈现比真正的 MAIN buffer 翻转要早，所以会闪一下
-            // 解决方法是在 gdi().present 里边统一呈现翻转
-            if (_firstVisibleRowId + i == _selectedRowId) {
-                if (_activeIcon.visible()) {
-                    continue;
-                }
-            }
-            s32 itemX = _position.x + 1;
-            s32 itemY = _position.y + i * _rowHeight + ((_rowHeight - 32) >> 1) - 1;
-            _romInfoList[_firstVisibleRowId + i].drawDSRomIcon(itemX, itemY, _engine, false);
+            s32 itemY = _position.y + i * _rowHeight + ((_rowHeight - icon_height) >> 1) - 1;
+            _romInfoList[_firstVisibleRowId + i].drawDSRomIcon(itemX, itemY, _engine, small);
         }
     }
 }
@@ -532,12 +518,8 @@ void cMainList::updateActiveIcon(bool updateContent) {
 
     // do not show active icon when hold key to list files. Otherwise the icon will not show
     // correctly.
-    if (VM_LIST_ICON == _viewMode){
-        _activeIcon.hide();
-        cwl();
-    }
-    else if (getInputIdleMs() > 1000 && VM_LIST != _viewMode && allowAnimation && _romInfoList.size() &&
-        0 == temp.keysHeld && gs().Animation) {
+    if (getInputIdleMs() > 1000 && VM_LIST != _viewMode && VM_LIST_ICON != _viewMode && allowAnimation &&
+        _romInfoList.size() && 0 == temp.keysHeld && gs().Animation) {
         if (!_activeIcon.visible()) {
             u8 backBuffer[32 * 32 * 2];
             zeroMemory(backBuffer, 32 * 32 * 2);
@@ -554,11 +536,9 @@ void cMainList::updateActiveIcon(bool updateContent) {
             for (u8 i = 0; i < 8; ++i) dbg_printf("%02x", backBuffer[i]);
             dbg_printf("\n");
         }
-    } else {
-        if (_activeIcon.visible()) {
-            _activeIcon.hide();
-            cwl();
-        }
+    } else if (_activeIcon.visible()) {
+        _activeIcon.hide();
+        cwl();
     }
 }
 


### PR DESCRIPTION
This makes no difference in functionality, it only removes some areas of duplicated code. This results in the size of the akmenu binary being reduced by about a kilobyte