### PR TITLE
Add support for Slot 2 RAM expansion in nds-bootstrap

### DIFF
--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -17,7 +17,7 @@ SOURCE_PATH := ../arm9
 # all directories are relative to this makefile
 #---------------------------------------------------------------------------------
 BUILD    := build
-SOURCES  := $(SOURCE_PATH)/source $(SOURCE_PATH)/source/ui $(SOURCE_PATH)/source/font $(SOURCE_PATH)/source/launcher $(SOURCE_PATH)/source/saves
+SOURCES  := $(SOURCE_PATH)/source $(SOURCE_PATH)/source/ui $(SOURCE_PATH)/source/font $(SOURCE_PATH)/source/launcher/slot2 $(SOURCE_PATH)/source/launcher $(SOURCE_PATH)/source/saves
 INCLUDES := $(SOURCE_PATH)/include ../share $(SOURCES)
 DATA     := $(SOURCE_PATH)/data ../data
 GRAPHICS :=

--- a/arm9/source/launcher/NdsBootstrapLauncher.cpp
+++ b/arm9/source/launcher/NdsBootstrapLauncher.cpp
@@ -29,12 +29,40 @@
 #include "nds_loader_arm9.h"
 #include "fsmngr.h"
 
+#include "slot2/io_g6_common.h"
+#include "slot2/io_m3_common.h"
+#include "slot2/io_sc_common.h"
+
 void smoothProgress(u8 start, u8 end) {
     for(u8 p = start; p <= end; p += 5) {
         progressWnd().setPercent(p);
         swiWaitForVBlank();
     }
     progressWnd().setPercent(end);
+}
+
+void slot2RamAccess(){
+    // if running from NDS slot
+    if (io_dldi_data->ioInterface.features & FEATURE_SLOT_NDS) {
+        sysSetCartOwner(BUS_OWNER_ARM9);
+
+        *(vu16*)0x08000000 = 0x1111;    // write data to GBA ROM area
+        // if data wasn't written, try enabling RAM access for various slot 2 carts and write again
+        if (*(vu16*)0x08000000 != 0x1111) {
+            _SC_changeMode(SC_MODE_RAM);
+            *(vu16*)0x08000000 = 0x1111;
+        }
+        if (*(vu16*)0x08000000 != 0x1111) {
+            _G6_SelectOperation(G6_MODE_RAM);
+            *(vu16*)0x08000000 = 0x1111;
+        }
+        if (*(vu16*)0x08000000 != 0x1111) {
+            _M3_changeMode(M3_MODE_RAM);
+            *(vu16*)0x08000000 = 0x1111;
+        }
+
+        sysSetCartOwner(BUS_OWNER_ARM7);
+    }
 }
 
 bool NdsBootstrapLauncher::prepareCheats() {
@@ -334,6 +362,11 @@ bool NdsBootstrapLauncher::launchRom(std::string romPath, std::string savePath, 
         }
         progressWnd().setTipText("Booting game...");
         smoothProgress(90, 100);
+    }
+
+    // enable slot2 ram access if available
+    if(!isDSiMode()){
+        slot2RamAccess();
     }
 
     // Launch

--- a/arm9/source/launcher/slot2/io_g6_common.c
+++ b/arm9/source/launcher/slot2/io_g6_common.c
@@ -1,0 +1,114 @@
+/*
+	iointerface.c for G6 flash card
+
+Written by Viruseb (viruseb@hotmail.com)
+	Many thanks to Puyo for his help in the reading code and ecc generation
+	and Theli for remote debbuging.
+
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+	
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+If you wish to understand how the code works, I encourage you reading 
+the datasheet of K9K4G08U0M nand flash device from Samsung before.
+
+Just some figures to keep in mind :
+	1 page  = 4 sectors + 64byte
+	1 block = 64 pages = 256 sectors
+	1 4G device = 4096 blocks
+
+The spare 64byte in page are use :
+	- to store the ECC. There is 3bytes ecc per 256bytes (bytes 8...15+numsector*16).
+	- to store lookuptable values (bytes 4..7).
+	
+04/12/06 : Version 0.10
+	Just freshly written. Not tested on real G6L thought. 
+	Extreme caution have to be taken when testing WriteBlockFunction 
+	since it may brick your G6L or more likely corrupt your data 
+	and formating can be necessary.
+	
+05/12/06 : Version 0.11
+	Thank to Theli, a lot of stupid mistakes removed, a lot of debugging done.
+	Reading code checked against Puyo's code. 
+	Device and FAT table is recognised by Fat_InitFiles()
+	Known issues : DMA read (G6_ReadDMA) is malfunctionning
+				Strange things append when trying to read more than 1 sectors at a time
+				Have to check LookUpTable values against Puyo's LookUpTable they seems differents after 512values 
+	
+19/12/06 : Version 0.12
+	Reading code ok
+	
+20/12/06 : Version 0.13
+	Some reading bugs corrected
+	
+07/01/07 : Version 0.14
+	Writing code finaly working. Need some optimizations.
+	
+10/01/07 : Version 0.15
+	Code cleaning. Need to add DMA R/W and use of cache programming in later version. 
+	
+03/02/07 : Version 0.16
+	Unaligned R/W supported.
+	Write code rewritten, using cache programming now.
+
+04/03/07 : Version 0.17
+	VerifyBlockFunc corrected (no more in use now)
+	
+23/03/07 : Version 0.18
+	a bug corrected in make_ecc_256
+	
+25/03/07 : Version 0.19
+	Improved writing speed
+*/
+
+#include "io_g6_common.h"
+
+static u16 _G6_readHalfword (u32 addr) {
+	return *((vu16*)addr);
+}
+
+/*-----------------------------------------------------------------
+SelectOperation
+?? 
+u16 op IN : Operation to select
+-----------------------------------------------------------------*/
+void _G6_SelectOperation(u16 op)
+{
+	_G6_readHalfword (0x09000000);
+	_G6_readHalfword (0x09FFFFE0);
+
+	_G6_readHalfword (0x09FFFFEC);
+	_G6_readHalfword (0x09FFFFEC);
+	_G6_readHalfword (0x09FFFFEC);
+
+	_G6_readHalfword (0x09FFFFFC);
+	_G6_readHalfword (0x09FFFFFC);
+	_G6_readHalfword (0x09FFFFFC);
+
+	_G6_readHalfword (0x09FFFF4A);
+	_G6_readHalfword (0x09FFFF4A);
+	_G6_readHalfword (0x09FFFF4A);
+
+	_G6_readHalfword (0x09200000 + (op<<1));
+	_G6_readHalfword (0x09FFFFF0);
+	_G6_readHalfword (0x09FFFFE8);
+}

--- a/arm9/source/launcher/slot2/io_g6_common.h
+++ b/arm9/source/launcher/slot2/io_g6_common.h
@@ -1,0 +1,103 @@
+/*
+	iointerface.c for G6 flash card
+
+Written by Viruseb (viruseb@hotmail.com)
+	Many thanks to Puyo for his help in the reading code and ecc generation
+	and Theli for remote debbuging.
+
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+	
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+If you wish to understand how the code works, I encourage you reading 
+the datasheet of K9K4G08U0M nand flash device from Samsung before.
+
+Just some figures to keep in mind :
+	1 page  = 4 sectors + 64byte
+	1 block = 64 pages = 256 sectors
+	1 4G device = 4096 blocks
+
+The spare 64byte in page are use :
+	- to store the ECC. There is 3bytes ecc per 256bytes (bytes 8...15+numsector*16).
+	- to store lookuptable values (bytes 4..7).
+	
+04/12/06 : Version 0.10
+	Just freshly written. Not tested on real G6L thought. 
+	Extreme caution have to be taken when testing WriteBlockFunction 
+	since it may brick your G6L or more likely corrupt your data 
+	and formating can be necessary.
+	
+05/12/06 : Version 0.11
+	Thank to Theli, a lot of stupid mistakes removed, a lot of debugging done.
+	Reading code checked against Puyo's code. 
+	Device and FAT table is recognised by Fat_InitFiles()
+	Known issues : DMA read (G6_ReadDMA) is malfunctionning
+				Strange things append when trying to read more than 1 sectors at a time
+				Have to check LookUpTable values against Puyo's LookUpTable they seems differents after 512values 
+	
+19/12/06 : Version 0.12
+	Reading code ok
+	
+20/12/06 : Version 0.13
+	Some reading bugs corrected
+	
+07/01/07 : Version 0.14
+	Writing code finaly working. Need some optimizations.
+	
+10/01/07 : Version 0.15
+	Code cleaning. Need to add DMA R/W and use of cache programming in later version. 
+	
+03/02/07 : Version 0.16
+	Unaligned R/W supported.
+	Write code rewritten, using cache programming now.
+
+04/03/07 : Version 0.17
+	VerifyBlockFunc corrected (no more in use now)
+	
+23/03/07 : Version 0.18
+	a bug corrected in make_ecc_256
+	
+25/03/07 : Version 0.19
+	Improved writing speed
+*/
+
+#ifndef IO_G6_COMMON_H
+#define IO_G6_COMMON_H
+
+#include <nds/ndstypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Values for changing mode
+#define G6_MODE_RAM 6
+#define G6_MODE_MEDIA 3 
+
+extern void _G6_SelectOperation(u16 op);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IO_G6_COMMON_H
+

--- a/arm9/source/launcher/slot2/io_m3_common.c
+++ b/arm9/source/launcher/slot2/io_m3_common.c
@@ -1,0 +1,60 @@
+/*
+	io_m3_common.c 
+
+	Routines common to all version of the M3
+	
+	Some code based on M3 SD drivers supplied by M3Adapter.
+	Some code written by SaTa may have been unknowingly used.
+
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+	
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "io_m3_common.h"
+
+static u16 _M3_readHalfword (u32 addr) {
+	return *((vu16*)addr);
+}
+
+void _M3_changeMode (u32 mode) {
+	_M3_readHalfword (0x08e00002);
+	_M3_readHalfword (0x0800000e);
+	_M3_readHalfword (0x08801ffc);
+	_M3_readHalfword (0x0800104a);
+	_M3_readHalfword (0x08800612);
+	_M3_readHalfword (0x08000000);
+	_M3_readHalfword (0x08801b66);
+	_M3_readHalfword (0x08000000 + (mode << 1));
+	_M3_readHalfword (0x0800080e);
+	_M3_readHalfword (0x08000000);
+	
+	if ((mode & 0x0f) != 4) {
+		_M3_readHalfword (0x09000000);
+	} else {
+		_M3_readHalfword (0x080001e4);
+		_M3_readHalfword (0x080001e4);
+		_M3_readHalfword (0x08000188);
+		_M3_readHalfword (0x08000188);
+	}
+}	
+

--- a/arm9/source/launcher/slot2/io_m3_common.h
+++ b/arm9/source/launcher/slot2/io_m3_common.h
@@ -1,0 +1,57 @@
+/*
+ io_m3_common.h 
+
+ Routines common to all version of the M3
+
+ Some code based on M3 SD drivers supplied by M3Adapter.
+ Some code written by SaTa may have been unknowingly used.
+
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+	
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+	2006-07-11 - Chishm
+		* Original release
+*/
+
+#ifndef IO_M3_COMMON_H
+#define IO_M3_COMMON_H
+
+#include <nds/ndstypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Values for changing mode
+#define M3_MODE_RAM 0x00400006
+#define M3_MODE_ROM 0x00400004
+#define M3_MODE_MEDIA 0x00400003 
+
+extern void _M3_changeMode (u32 mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IO_M3_COMMON_H
+

--- a/arm9/source/launcher/slot2/io_sc_common.c
+++ b/arm9/source/launcher/slot2/io_sc_common.c
@@ -1,0 +1,47 @@
+/*
+	io_m3_common.h 
+
+	Routines common to all version of the Super Card
+
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+	
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "io_sc_common.h"
+
+/*-----------------------------------------------------------------
+_SC_changeMode (was SC_Unlock)
+Added by MightyMax
+Modified by Chishm
+Modified again by loopy
+1=ram(readonly), 5=ram, 3=SD interface?
+-----------------------------------------------------------------*/
+void _SC_changeMode(u8 mode) {
+	vu16 *unlockAddress = (vu16*)0x09FFFFFE;
+	*unlockAddress = 0xA55A ;
+	*unlockAddress = 0xA55A ;
+	*unlockAddress = mode ;
+	*unlockAddress = mode ;
+} 
+
+

--- a/arm9/source/launcher/slot2/io_sc_common.h
+++ b/arm9/source/launcher/slot2/io_sc_common.h
@@ -1,0 +1,53 @@
+/*
+ io_sc_common.h 
+
+ Routines common to all version of the Super Card
+
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+	
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+	2006-07-11 - Chishm
+		* Original release
+*/
+
+#ifndef IO_SC_COMMON_H
+#define IO_SC_COMMON_H
+
+#include <nds/ndstypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Values for changing mode
+#define SC_MODE_RAM 0x5
+#define SC_MODE_MEDIA 0x3 
+#define SC_MODE_RAM_RO 0x1
+
+extern void _SC_changeMode (u8 mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IO_SC_COMMON_H

--- a/licenses/BSD3.txt
+++ b/licenses/BSD3.txt
@@ -1,0 +1,22 @@
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/README.txt
+++ b/licenses/README.txt
@@ -2,6 +2,8 @@ This program is originally based on the akmenu project by the Acekard team, who 
 
 This program is further developed by yellow wood goblin, who released the source under the GPL-3.0-or-later license. See GPL3.txt for more info.
 
+This provided source integrates Slot-2 cartridge interface code from Chishm, which is licensed under the BSD-3-Clause license. See BSD3.txt for more info,
+
 This provided source integrates ROM list code from the melonDS project, which is licensed under the GPL-3.0-or-later license. See GPL3.txt for more info.
 
 This provided source integrates devkitPro's bootloader, which is licensed under the GPL-2.0-or-later license. See GPL2.txt for more info.

--- a/package/_nds/akmenunext/redist/BSD3.txt
+++ b/package/_nds/akmenunext/redist/BSD3.txt
@@ -1,0 +1,24 @@
+Slot-2 G6, M3 and SuperCard IO interface code used in AKMenu-Next is licensed under the BSD-3-Clause license:
+
+ Copyright (c) 2006 Michael "Chishm" Chisholm
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation and/or
+     other materials provided with the distribution.
+  3. The name of the author may not be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This patch will fix the issue mentioned in #32. 

It will do checks to see if nds-bootstrap is being run from Slot-1 in DS mode. If it is, it will try to write data to the GBA ROM area. If it cannot find the data that was written there, it will enable RAM access to various Slot-2 flashcarts then check again to see if data can be written to that area. With this in place, games can now boot from Slot-1 while a Slot-2 flashcart is inserted.

This should not affect the DSi nor 3DS in any way