### PR TITLE
Startup in favourites support // Select last rom on startup support

### DIFF
--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -196,8 +196,11 @@ int main(int argc, char* argv[]) {
     }
 
     dbg_printf("lastDirectory '%s'\n", lastDirectory.c_str());
-    if (!wnd->_mainList->enterDir("..." != lastDirectory ? lastDirectory : gs().startupFolder))
+    if (!wnd->_mainList->enterDir("..." != lastDirectory ? lastDirectory : gs().startupFolder)) {
         wnd->_mainList->enterDir("...");
+    } else {
+        wnd->_mainList->selectRom(lastFile);
+    }
 
     *(u32*)(0xCFFFD0C) = 0x454D4D43;
     while (*(u32*)(0xCFFFD0C) != 0) {

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -136,16 +136,21 @@ int main(int argc, char* argv[]) {
     irq().vblankStart();
 
     // enter last directory
-    std::string lastDirectory = "...", lastFile = "...";
+    std::string lastDirectory = "...", lastFile = "...", favorite = "no";
     if (gs().enterLastDirWhenBoot || gs().autorunWithLastRom) {
         CIniFile f;
         if (f.LoadIniFile(SFN_LAST_SAVEINFO)) {
             lastFile = f.GetString("Save Info", "lastLoaded", "");
+            favorite = f.GetString("Save Info", "favorite", "no");
             if ("" == lastFile) {
                 lastFile = "...";
             } else if (gs().enterLastDirWhenBoot) {
-                size_t slashPos = lastFile.find_last_of('/');
-                if (lastFile.npos != slashPos) lastDirectory = lastFile.substr(0, slashPos + 1);
+                if (favorite == "yes") {
+                    lastDirectory = "favorites:/";
+                } else {
+                    size_t slashPos = lastFile.find_last_of('/');
+                    if (lastFile.npos != slashPos) lastDirectory = lastFile.substr(0, slashPos + 1);
+                }
             }
         }
     }
@@ -201,7 +206,7 @@ int main(int argc, char* argv[]) {
 
     if (gs().autorunWithLastRom && "..." != lastFile) {
         INPUT& inputs = updateInput();
-        if (!(inputs.keysHeld & KEY_B)) autoLaunchRom(lastFile);
+        if (!(inputs.keysHeld & KEY_B)) autoLaunchRom(lastFile, favorite);
     }
 
     while (true) {

--- a/arm9/source/mainlist.cpp
+++ b/arm9/source/mainlist.cpp
@@ -444,6 +444,15 @@ void cMainList::setRomInfo(u32 rowIndex, const DSRomInfo& info) {
     }
 }
 
+void cMainList::selectRom(const std::string& romPath){
+    for(unsigned int row = 0; row < _rows.size(); row++){
+        if(romPath == _rows[row][REALNAME_COLUMN].text()){
+            selectRow(row);
+            break;
+        }
+    }
+}
+
 void cMainList::draw() {
     updateInternalNames();
     cListView::draw();

--- a/arm9/source/mainlist.h
+++ b/arm9/source/mainlist.h
@@ -53,6 +53,8 @@ class cMainList : public akui::cListView {
 
     void setRomInfo(u32 rowIndex, const DSRomInfo& info);
 
+    void selectRom(const std::string& romPath);
+
     void setViewMode(VIEW_MODE mode);
 
     std::string getSelectedFullPath();

--- a/arm9/source/mainwnd.cpp
+++ b/arm9/source/mainwnd.cpp
@@ -414,7 +414,7 @@ void cMainWnd::launchSelected() {
     progressWnd().show();
     progressWnd().setPercent(0);
     switch (launchRom(fullPath, rominfo,
-                      rominfo.isHomebrew() && "BOOT.NDS" == _mainList->getSelectedShowName(), savesPath)) {
+                      rominfo.isHomebrew() && "BOOT.NDS" == _mainList->getSelectedShowName(), savesPath, _mainList->IsFavorites() ? "yes" : "no")) {
         case ELaunchNoFreeSpace:
             title = LANG("no free space", "title");
             text = LANG("no free space", "text");

--- a/arm9/source/romlauncher.cpp
+++ b/arm9/source/romlauncher.cpp
@@ -132,7 +132,7 @@ static u32 SaveSize(SAVE_TYPE st) {
     return result;
 }
 
-TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool aMenu, const std::string& savesPath) {
+TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool aMenu, const std::string& savesPath, const std::string& favorite) {
     u32 flags = 0;
     long cheatOffset = 0;
     size_t cheatSize = 0;
@@ -200,7 +200,7 @@ TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool 
                                                          bigSaveSize);
             if (!isBigSave) return ELaunchNoFreeSpace;
             flags |= PATCH_SD_SAVE | (bigSaveMask << PATCH_SAVE_SHIFT);
-            saveManager().saveLastInfo(aFullPath);
+            saveManager().saveLastInfo(aFullPath, favorite);
         } else {
             SAVE_TYPE st = (SAVE_TYPE)aRomInfo.saveInfo().saveType;
             if (ST_UNKNOWN == st) st = ST_AUTO;
@@ -217,7 +217,7 @@ TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool 
                 if (cSaveManager::initializeSaveFile(useSavesPath, aRomInfo.saveInfo().getSlot(),
                 SaveSize(st))) {
                 flags |= PATCH_SD_SAVE | (SaveMask(st) << PATCH_SAVE_SHIFT);
-                saveManager().saveLastInfo(aFullPath);
+                saveManager().saveLastInfo(aFullPath, favorite);
                 } else {
                 return ELaunchNoFreeSpace;
                 }
@@ -255,7 +255,7 @@ TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool 
         }
 
     } else {
-        if (!aMenu) saveManager().saveLastInfo(aFullPath);
+        if (!aMenu) saveManager().saveLastInfo(aFullPath, favorite);
         if (gs().hbStrap == 1)
         {
             hb = true;
@@ -269,8 +269,8 @@ TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool 
     return ELaunchRomOk;
 }
 
-void autoLaunchRom(const std::string& aFullPath) {
+void autoLaunchRom(const std::string& aFullPath, const std::string& favorite) {
     DSRomInfo rominfo;
     rominfo.MayBeDSRom(aFullPath);
-    if (rominfo.isDSRom()) launchRom(aFullPath, rominfo, false, "");
+    if (rominfo.isDSRom()) launchRom(aFullPath, rominfo, false, "", favorite);
 }

--- a/arm9/source/romlauncher.h
+++ b/arm9/source/romlauncher.h
@@ -17,5 +17,5 @@ enum TLaunchResult {
     ELaunchNoFreeSpace
 };
 
-TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool aMenu, const std::string& savesPath);
-void autoLaunchRom(const std::string& aFullPath);
+TLaunchResult launchRom(const std::string& aFullPath, DSRomInfo& aRomInfo, bool aMenu, const std::string& savesPath, const std::string& favorite);
+void autoLaunchRom(const std::string& aFullPath, const std::string& favorite);

--- a/arm9/source/savemngr.cpp
+++ b/arm9/source/savemngr.cpp
@@ -137,9 +137,10 @@ void cSaveManager::updateCustomSaveList(const SAVE_INFO_EX& aSaveInfo) {
     exportCustomSaveList(SFN_CUSTOM_SAVELIST);
 }
 
-bool cSaveManager::saveLastInfo(const std::string& romFilename) {
+bool cSaveManager::saveLastInfo(const std::string& romFilename, const std::string& favorite) {
     CIniFile f;
     f.SetString("Save Info", "lastLoaded", romFilename);
+    f.SetString("Save Info", "favorite", favorite);
     if (!f.SaveIniFile(SFN_LAST_SAVEINFO)) return false;
 
     return true;
@@ -161,7 +162,7 @@ bool cSaveManager::loadLastInfo(std::string& lastLoadedFilename) {
 bool cSaveManager::clearLastInfo() {
     std::string loadLoadedFile;
     if (loadLastInfo(loadLoadedFile)) {
-        return saveLastInfo("");
+        return saveLastInfo("","");
     }
     return true;
 }

--- a/arm9/source/savemngr.h
+++ b/arm9/source/savemngr.h
@@ -217,7 +217,7 @@ class cSaveManager {
 
     void updateCustomSaveList(const SAVE_INFO_EX& aSaveInfo);
 
-    bool saveLastInfo(const std::string& romFilename);
+    bool saveLastInfo(const std::string& romFilename, const std::string& favorite);
 
     bool loadLastInfo(std::string& lastLoadedFilename);
 


### PR DESCRIPTION
This PR implements both suggestions from issue #15. AKMenu can now autoload into the favourites folder if a game has been launched from there. It will also select the last run ROM if it is available in the list.